### PR TITLE
Migrate from `pykalman` to `pykalman-bardo`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ channels==3.0.4
 Django==4.0.2
 numpy==1.22.2
 pandas==1.4.1
-pykalman==0.9.5
+pykalman-bardo==0.9.6
 pyserial==3.5
 scipy==1.8.0
 websocket-client==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ channels==3.0.4
 Django==4.0.2
 numpy==1.22.2
 pandas==1.4.1
-pykalman-bardo==0.9.6
+pykalman-bardo==0.9.7
 pyserial==3.5
 scipy==1.8.0
 websocket-client==1.3.1


### PR DESCRIPTION
Consider migration from `pykalman` to `pykalman-bardo`, as [pykalman](https://github.com/pykalman/pykalman) project is no longer maintained. There were some issues that were fixed, see: https://github.com/pybardo/pykalman/blob/v0.9.7/CHANGELOG

I'm going to maintain [pykalman-bardo](https://github.com/pybardo/pykalman), react to issues, and fix bugs. For now the API is the same as in the initial package, but it might evolve in time.

I hope you will find it useful for your project!